### PR TITLE
Add simple ChatGPT web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# expt_ai
+# ChatGPT Web Interface
+
+This project provides a simple Flask-based web interface for sending a prompt to ChatGPT and displaying the result.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Export your OpenAI API key as an environment variable:
+
+```bash
+export OPENAI_API_KEY=your_key_here
+```
+
+3. Run the server:
+
+```bash
+python app.py
+```
+
+Then open `http://localhost:5000` in your browser.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,33 @@
+import os
+from flask import Flask, render_template, request
+import openai
+
+app = Flask(__name__)
+
+# Set OpenAI API key from environment variable
+openai.api_key = os.environ.get("OPENAI_API_KEY")
+
+@app.route('/', methods=['GET'])
+def index():
+    """Render form for user input."""
+    return render_template('index.html')
+
+@app.route('/chat', methods=['POST'])
+def chat():
+    """Handle form submission and query ChatGPT."""
+    user_message = request.form.get('message', '')
+    if not user_message:
+        return render_template('index.html', error='Please enter a message')
+
+    try:
+        completion = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": user_message}]
+        )
+        response = completion.choices[0].message.content
+    except Exception as e:
+        response = f"Error communicating with OpenAI API: {e}"
+    return render_template("index.html", user_message=user_message, response=response)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+openai

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>ChatGPT Interface</title>
+</head>
+<body>
+    <h1>ChatGPT Web Interface</h1>
+    {% if error %}
+    <p style="color: red;">{{ error }}</p>
+    {% endif %}
+    <form method="post" action="/chat">
+        <textarea name="message" rows="4" cols="50">{{ user_message or '' }}</textarea><br>
+        <input type="submit" value="Submit">
+    </form>
+    {% if response %}
+    <h2>Response:</h2>
+    <p>{{ response }}</p>
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create Flask-based app to send prompts to ChatGPT and render results
- add basic HTML template with textarea and submit button
- provide requirements and instructions in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686c2e25c88c8322a8d93649a1e3b46c